### PR TITLE
BugFix: LOC-13 error on executing via command line

### DIFF
--- a/octoprint_SD3D/__init__.py
+++ b/octoprint_SD3D/__init__.py
@@ -298,8 +298,12 @@ class SD3DPlugin(octoprint.plugin.StartupPlugin,
                 if request.args.get('autoprint_setting') == '1':
                         return flask.jsonify(result=self._settings.get(['autoPrintMode']))
                 
+		# grant permission to the file before execute it
+		commands = ['/bin/chmod +x /home/pi/oprint/lib/python2.7/site-packages/octoprint_SD3D/qr.py']
 		import subprocess
-   
+		for command in commands:
+                        subprocess.check_call("/bin/bash -c 'sudo {}'".format(command), shell=True)
+
                 qr_script_path = '/home/pi/oprint/lib/python2.7/site-packages/octoprint_SD3D/qr.py'
                 subprocess_args = [qr_script_path]
 


### PR DESCRIPTION
Updating or reinstalling the plugin does not work without usage of the command line